### PR TITLE
Added <resources> for frontend

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -42,14 +42,17 @@
 				<filtering>true</filtering>
 				<directory>${project.basedir}</directory>
 				<includes>
-					<include>output/**</include>
-					<include>**/*.html</include>
+					<include>output/index.min.js</include>
+					<include>index.html</include>
+					<include>node_modules/bootstrap/dist/css/bootstrap.min.css</include>
 				</includes>
-				<excludes>
-					<exclude>node/**</exclude>
-					<exclude>node_modules/**</exclude>
-					<exclude>node</exclude>
-				</excludes>
+			</resource>
+			<resource>
+				<filtering>false</filtering>
+				<directory>${project.basedir}</directory>
+				<includes>
+					<include>node_modules/bootstrap/dist/fonts/**</include>
+				</includes>
 			</resource>
 		</resources>
 		<plugins>

--- a/ui/readme.md
+++ b/ui/readme.md
@@ -31,11 +31,11 @@ Run
 Navigate to _http://localhost:3000/dev.html_ The browser will be automatically updated
  whenever you save some changes.
 
-To get the project ready for production, run just
+To get the project ready for production, run
 
-    webpack
+    maven package
 
-That will minify and optimize the scripts, use _index.html_ for production.
+Don't forget to add resources necessary for production in _pom.xml_
 
 ### Debugging
 Add the "debug" key to the local storage to get debug messages


### PR DESCRIPTION
Added frontend resources to pom.xml
This pull request is mutually exclusive with gulp-build
Unlike gulp-build, all subsequent resources need to be manually added to pom.xml This particularity is documented.

P.S.: Bootstrap resources need to be included with _filtering:false_ because filtering breaks binary files, see http://stackoverflow.com/questions/19500458/maven-resource-binary-changes-file-size-after-build