### PR TITLE
Fix issues caused by the fixed navbar

### DIFF
--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/BasePage.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/BasePage.html
@@ -12,7 +12,7 @@
             <header class="main-header" wicket:id="header"></header>
 
             <div class="row">
-                <div align="center">
+                <div class="text-center">
                     <h3 wicket:id="pageTitle"></h3>
                 </div>
             </div>

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/BasePage.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/BasePage.html
@@ -3,14 +3,14 @@
     <head>
         <meta charset="utf-8">
         <title>DGToolkit</title>
-
-
     </head>
 
     <body>
-      	<wicket:container wicket:id="scripts-container"/>
+        <wicket:container wicket:id="scripts-container"/>
+
         <div class="container-fluid">
-            <header wicket:id="header"></header>
+            <header class="main-header" wicket:id="header"></header>
+
             <div class="row">
                 <div align="center">
                     <h3 wicket:id="pageTitle"></h3>
@@ -26,8 +26,8 @@
                 </div>
             </div>
 
-            <footer class="footer" wicket:id="footer"></footer>
+            <footer class="main-footer" wicket:id="footer"></footer>
         </div>
-     
+
     </body>
 </html>

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/BasePage.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/BasePage.java
@@ -38,8 +38,10 @@ import org.devgateway.toolkit.forms.wicket.page.lists.ListGroupPage;
 import org.devgateway.toolkit.forms.wicket.page.lists.ListTestFormPage;
 import org.devgateway.toolkit.forms.wicket.page.user.EditUserPage;
 import org.devgateway.toolkit.forms.wicket.page.user.LogoutPage;
+import org.devgateway.toolkit.forms.wicket.styles.BaseStyles;
 import org.devgateway.toolkit.persistence.dao.Person;
 
+import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameAppender;
 import de.agilecoders.wicket.core.markup.html.bootstrap.button.dropdown.MenuBookmarkablePageLink;
 import de.agilecoders.wicket.core.markup.html.bootstrap.common.NotificationPanel;
 import de.agilecoders.wicket.core.markup.html.bootstrap.html.HtmlTag;
@@ -110,6 +112,9 @@ public abstract class BasePage extends GenericWebPage<Void> {
 		navbar = newNavbar("navbar");
 		header.add(navbar);
 
+		// Add information about navbar position on header element.
+		header.add(new CssClassNameAppender("with-" + navbar.getPosition().cssClassName()));
+
 		footer = new Footer("footer");
 
 		add(header);
@@ -143,6 +148,10 @@ public abstract class BasePage extends GenericWebPage<Void> {
 		logoutMenu.setIconType(GlyphIconType.logout);
 		MetaDataRoleAuthorizationStrategy.authorize(logoutMenu, Component.RENDER, SecurityConstants.Roles.ROLE_EDITOR);
 
+		/**
+		 * Make sure to update the BaseStyles when the navbar position changes.
+		 * @see org.devgateway.toolkit.forms.wicket.styles.BaseStyles
+		 */
 		navbar.setPosition(Navbar.Position.TOP);
 		navbar.setInverted(true);
 
@@ -211,9 +220,9 @@ public abstract class BasePage extends GenericWebPage<Void> {
 				list.add(uiBrowserLink);
 
 
-                list.add(new MenuBookmarkablePageLink<Void>(EditAdminSettingsPage.class,
-                        new StringResourceModel("navbar.adminSettings", BasePage.this, null)).
-                        setIconType(FontAwesomeIconType.briefcase));
+				list.add(new MenuBookmarkablePageLink<Void>(EditAdminSettingsPage.class,
+						new StringResourceModel("navbar.adminSettings", BasePage.this, null)).
+						setIconType(FontAwesomeIconType.briefcase));
 
 				return list;
 			}
@@ -232,17 +241,18 @@ public abstract class BasePage extends GenericWebPage<Void> {
 	public void renderHead(final IHeaderResponse response) {
 		super.renderHead(response);
 
-		// response.render(CssHeaderItem.forReference(MainCss.INSTANCE));
-
-		response.render(RespondJavaScriptReference.headerItem());
-
+		// Load Styles.
+		response.render(CssHeaderItem.forReference(BaseStyles.INSTANCE));
 		response.render(CssHeaderItem.forReference(BootstrapCssReference.instance()));
 		response.render(CssHeaderItem.forReference(FontAwesomeCssReference.instance()));
 
+		// Load Scripts.
+		response.render(RespondJavaScriptReference.headerItem());
 		response.render(JavaScriptHeaderItem.forReference(JQueryResourceReference.get()));
-		// response.render(JavaScriptHeaderItem.forReference(new
-		// JavaScriptResourceReference(MainCss.class,
-		// "/assets/js/fileupload.js")));
+
+		// response.render(JavaScriptHeaderItem.forReference(
+		// 		new JavaScriptResourceReference(MainCss.class, "/assets/js/fileupload.js")
+		// ));
 
 	}
 }

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/user/ForgotYourPasswordPage.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/user/ForgotYourPasswordPage.html
@@ -6,9 +6,6 @@
 </head>
 <body>
 <wicket:extend>
-    <section class="padding50">
-        <div style="clear:both; height: 20px"></div>
-    </section>
     <div class="row">
         <div class="col-md-4 col-md-offset-4 well">
             <form wicket:id="form">

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/user/LoginPage.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/user/LoginPage.html
@@ -6,9 +6,6 @@
 </head>
 <body>
 	<wicket:extend>
-        <section class="padding50">
-            <div style="clear:both; height: 50px"></div>
-        </section>
         <div class="row">
             <div class="col-md-2 col-md-offset-5 well">
                 <form wicket:id="loginform">

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.css
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.css
@@ -1,0 +1,26 @@
+/**
+ * @file
+ * This file contains the basic style for any page.
+ */
+
+html {
+    /*
+     * Always show page scroll-bar to prevent side-movement when hovering over items that are extending their height and
+     * suddenly the content doesn't fit above the fold.
+     */
+    overflow-y: scroll;
+}
+
+
+/**
+ * The header doesn't have any height when the navbar is fixed, and other elements are behind it.
+ *
+ * @see: Navbar.Position.TOP
+ * @see: bootstrap::navbar.less
+ */
+.main-header.with-navbar-fixed-top {
+    /*
+     * The default bootstrap navbar is 50px height and has a bottom margin of 20px for the default font size.
+     */
+    min-height: 70px;
+}

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.css
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.css
@@ -21,6 +21,8 @@ html {
 .main-header.with-navbar-fixed-top {
     /*
      * The default bootstrap navbar is 50px height and has a bottom margin of 20px for the default font size.
+     * TODO: Convert to LESS and use Bootstrap variables.
      */
-    min-height: 70px;
+    min-height: 50px;
+    margin-bottom: 20px;
 }

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.java
@@ -16,7 +16,7 @@ import org.apache.wicket.request.resource.CssResourceReference;
 /**
  * The base CSS for the project.
  *
- * TODO: Convert to LESS, SASS, or something.
+ * TODO: Convert to LESS; Bootstrap also uses LESS.
  */
 public class BaseStyles extends CssResourceReference {
 	private static final long serialVersionUID = 1L;

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Development Gateway, Inc and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the MIT License (MIT)
+ * which accompanies this distribution, and is available at
+ * https://opensource.org/licenses/MIT
+ *
+ * Contributors:
+ * Development Gateway - initial API and implementation
+ *******************************************************************************/
+package org.devgateway.toolkit.forms.wicket.styles;
+
+import org.apache.wicket.request.resource.CssResourceReference;
+
+/**
+ * The base CSS for the project.
+ *
+ * TODO: Convert to LESS, SASS, or something.
+ */
+public class BaseStyles extends CssResourceReference {
+	private static final long serialVersionUID = 1L;
+
+	public static final BaseStyles INSTANCE = new BaseStyles();
+
+	/**
+	 * Construct.
+	 */
+	public BaseStyles() {
+		super(BaseStyles.class, "BaseStyles.css");
+	}
+}


### PR DESCRIPTION
Added BaseStyles.css in order to:
* Fix item visibility issues cause by the fixed navigation bar.
* Make the scrollbar is always visible.
* Removed spacing element used on pages that don't have a title. Note: the page title was almost always behind the navbar, so this actually made the top of the pages usable.