### PR TITLE
Revert "fixes #83" -> fixes #243

### DIFF
--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/GenericBootstrapFormComponent.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/GenericBootstrapFormComponent.java
@@ -18,8 +18,6 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.form.InputBehavior.Size;
 import de.agilecoders.wicket.core.util.Attributes;
 import org.apache.log4j.Logger;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
-import org.apache.wicket.ajax.attributes.ThrottlingSettings;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.event.IEvent;
@@ -30,7 +28,6 @@ import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
-import org.apache.wicket.util.time.Duration;
 import org.devgateway.toolkit.forms.models.SubComponentWrapModel;
 import org.devgateway.toolkit.forms.models.ViewModeConverterModel;
 import org.devgateway.toolkit.forms.wicket.components.ComponentUtil;
@@ -60,10 +57,6 @@ public abstract class GenericBootstrapFormComponent<TYPE, FIELD extends FormComp
 
     protected IModel<String> labelModel;
 
-    //prevents repainting of select boxes and other problems with triggering the update even while the component js
-    //is not done updating.
-    private static final int THROTTLE_UPDATE_DELAY_MS = 200;
-
     @Override
     public void onEvent(final IEvent<?> event) {
         ComponentUtil.enableDisableEvent(this, event);
@@ -84,13 +77,6 @@ public abstract class GenericBootstrapFormComponent<TYPE, FIELD extends FormComp
     protected void getAjaxFormChoiceComponentUpdatingBehavior() {
         updatingBehaviorComponent().add(new AjaxFormChoiceComponentUpdatingBehavior() {
             private static final long serialVersionUID = 1L;
-
-            @Override
-            protected void updateAjaxAttributes(final AjaxRequestAttributes attributes) {
-                attributes.setThrottlingSettings(new ThrottlingSettings(
-                        Duration.milliseconds(THROTTLE_UPDATE_DELAY_MS)));
-                super.updateAjaxAttributes(attributes);
-            }
 
             @Override
             protected void onUpdate(final AjaxRequestTarget target) {
@@ -119,13 +105,6 @@ public abstract class GenericBootstrapFormComponent<TYPE, FIELD extends FormComp
         updatingBehaviorComponent().add(new AjaxFormComponentUpdatingBehavior(getUpdateEvent()) {
 
             private static final long serialVersionUID = -2696538086634114609L;
-
-            @Override
-            protected void updateAjaxAttributes(final AjaxRequestAttributes attributes) {
-                attributes.setThrottlingSettings(new ThrottlingSettings(
-                        Duration.milliseconds(THROTTLE_UPDATE_DELAY_MS)));
-                super.updateAjaxAttributes(attributes);
-            }
 
             @Override
             protected void onUpdate(final AjaxRequestTarget target) {


### PR DESCRIPTION
This reverts commit 03c0bc9cb9657822d51f271bc3f341b733521a52.

The change tested in a mirror repository that both #243 is fixed and the original #83 not reproduces. Please note that the latest DG Toolkit is based on Wicket 8, while #83 was fixed with Wicket 7.