### PR TITLE
Revert "fixes #83" fixes #243

### DIFF
--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/GenericBootstrapFormComponent.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/GenericBootstrapFormComponent.java
@@ -18,8 +18,6 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.form.InputBehavior.Size;
 import de.agilecoders.wicket.core.util.Attributes;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
-import org.apache.wicket.ajax.attributes.ThrottlingSettings;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.event.IEvent;
@@ -33,7 +31,6 @@ import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.ResourceModel;
-import org.apache.wicket.util.time.Duration;
 import org.devgateway.toolkit.forms.models.SubComponentWrapModel;
 import org.devgateway.toolkit.forms.models.ViewModeConverterModel;
 import org.devgateway.toolkit.forms.wicket.components.FieldPanel;
@@ -57,10 +54,6 @@ import java.util.List;
  */
 public abstract class GenericBootstrapFormComponent<TYPE, FIELD extends FormComponent<TYPE>> extends FieldPanel<TYPE> {
     private static final long serialVersionUID = -7051128382707812456L;
-
-    // prevents repainting of select boxes and other problems with triggering the update
-    // even while the component js is not done updating.
-    private static final int THROTTLE_UPDATE_DELAY_MS = 200;
 
     protected FormGroup border;
 
@@ -226,13 +219,6 @@ public abstract class GenericBootstrapFormComponent<TYPE, FIELD extends FormComp
     private void getAjaxFormChoiceComponentUpdatingBehavior() {
         updatingBehaviorComponent().add(new AjaxFormChoiceComponentUpdatingBehavior() {
             @Override
-            protected void updateAjaxAttributes(final AjaxRequestAttributes attributes) {
-                attributes.setThrottlingSettings(new ThrottlingSettings(
-                        Duration.milliseconds(THROTTLE_UPDATE_DELAY_MS)));
-                super.updateAjaxAttributes(attributes);
-            }
-
-            @Override
             protected void onUpdate(final AjaxRequestTarget target) {
                 GenericBootstrapFormComponent.this.onUpdate(target);
             }
@@ -256,13 +242,6 @@ public abstract class GenericBootstrapFormComponent<TYPE, FIELD extends FormComp
         }
         updatingBehaviorComponent().add(new AjaxFormComponentUpdatingBehavior(getUpdateEvent()) {
             private static final long serialVersionUID = -2696538086634114609L;
-
-            @Override
-            protected void updateAjaxAttributes(final AjaxRequestAttributes attributes) {
-                attributes.setThrottlingSettings(new ThrottlingSettings(
-                        Duration.milliseconds(THROTTLE_UPDATE_DELAY_MS)));
-                super.updateAjaxAttributes(attributes);
-            }
 
             @Override
             protected void onUpdate(final AjaxRequestTarget target) {


### PR DESCRIPTION
This reverts commit 03c0bc9cb9657822d51f271bc3f341b733521a52.

The change tested in a mirror repository that both #243 is fixed and the original #83 not reproduces. Please note that the latest DG Toolkit is based on Wicket 8, while #83 was fixed with Wicket 7.