### PR TITLE
feature/4.x/forms csp compliant

### DIFF
--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/FormsWebApplication.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/FormsWebApplication.java
@@ -31,6 +31,7 @@ import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AjaxNewWindowNotifyingBehavior;
 import org.apache.wicket.authroles.authentication.AuthenticatedWebApplication;
 import org.apache.wicket.authroles.authentication.AuthenticatedWebSession;
+import org.apache.wicket.csp.CSPDirective;
 import org.apache.wicket.markup.head.filter.JavaScriptFilteredIntoFooterHeaderResponse;
 import org.apache.wicket.markup.html.IPackageResourceGuard;
 import org.apache.wicket.markup.html.SecurePackageResourceGuard;
@@ -240,6 +241,13 @@ public class FormsWebApplication extends AuthenticatedWebApplication {
         // TODO make Wicket usage CSP compliant (temporarily disabled)
         // https://ci.apache.org/projects/wicket/guide/9.x/single.html#_content_security_policy_csp
         getCspSettings().blocking().disabled();
+        /*
+        // wicket-bootstrap-extension has to be CSP compliant to enable it
+        getCspSettings().blocking()
+                .strict()
+                // whitelist images rendered via data:
+                .add(CSPDirective.IMG_SRC, "data:");
+         */
     }
 
     /**

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/BootstrapDeleteButton.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/BootstrapDeleteButton.java
@@ -20,10 +20,10 @@ import de.agilecoders.wicket.extensions.markup.html.bootstrap.spinner.SpinnerAja
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxCallListener;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
-import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.event.IEvent;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnEventHeaderItem;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.Model;
 import org.devgateway.toolkit.forms.wicket.components.ComponentUtil;
 import org.devgateway.toolkit.forms.wicket.events.EditingDisabledEvent;
 
@@ -53,13 +53,17 @@ public abstract class BootstrapDeleteButton extends SpinnerAjaxButton {
     @Override
     protected void onInitialize() {
         super.onInitialize();
-        add(new AttributeAppender("onclick", new Model<String>("window.onbeforeunload = null;"), " "));
         setDefaultFormProcessing(false);
         setIconType(FontAwesome5IconType.trash_s);
 
         if (ComponentUtil.isViewMode()) {
             setVisibilityAllowed(false);
         }
+    }
+
+    public void renderHead(IHeaderResponse response) {
+        super.renderHead(response);
+        response.render(OnEventHeaderItem.forComponent(this, "onclick", "window.onbeforeunload = null;"));
     }
 
     @Override

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/DateTimeFieldBootstrapFormComponent.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/DateTimeFieldBootstrapFormComponent.java
@@ -10,13 +10,13 @@
  * Development Gateway - initial API and implementation
  *******************************************************************************/
 /**
- * 
+ *
  */
 package org.devgateway.toolkit.forms.wicket.components.form;
 
+import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameAppender;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.datetime.DatetimePicker;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.datetime.DatetimePickerConfig;
-import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.IndicatingAjaxLink;
 import org.apache.wicket.model.IModel;
@@ -25,7 +25,7 @@ import java.util.Date;
 
 /**
  * @author mpostelnicu
- * 
+ *
  */
 public class DateTimeFieldBootstrapFormComponent extends GenericBootstrapFormComponent<Date, DatetimePicker> {
     private static final long serialVersionUID = 6829640010904041758L;
@@ -69,7 +69,7 @@ public class DateTimeFieldBootstrapFormComponent extends GenericBootstrapFormCom
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.devgateway.toolkit.forms.wicket.components.form.
      * GenericBootstrapFormComponent#onConfigure()
      */
@@ -77,7 +77,7 @@ public class DateTimeFieldBootstrapFormComponent extends GenericBootstrapFormCom
     protected void onInitialize() {
         super.onInitialize();
 
-        border.add(new AttributeModifier("style", "position:relative;"));
+        border.add(new CssClassNameAppender("position-relative"));
 
         IndicatingAjaxLink<String> clearDateLink = new IndicatingAjaxLink<String>("clearDate") {
             private static final long serialVersionUID = -1705495886974891511L;

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/FileInputBootstrapFormComponentWrapper.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/FileInputBootstrapFormComponentWrapper.html
@@ -16,8 +16,8 @@
                             <a wicket:id="downloadLink"><span wicket:id="downloadText"/></a>
                         </td>
                         <td class="col-md-2">
-                            <i style="cursor: pointer;" wicket:id="download"/>
-                            <i style="cursor: pointer;" wicket:id="delete"/>
+                            <i role="button" wicket:id="download"/>
+                            <i role="button" wicket:id="delete"/>
                         </td>
                     </tr>
                 </tbody>
@@ -39,7 +39,7 @@
                             <span wicket:id="fileTitle"/>
                         </td>
                         <td class="col-md-2">
-                            <i style="cursor: pointer;" wicket:id="delete"/>
+                            <i role="button" wicket:id="delete"/>
                         </td>
                     </tr>
                 </tbody>

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/PercentageFieldBootstrapFormComponent.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/PercentageFieldBootstrapFormComponent.html
@@ -3,12 +3,11 @@
     xmlns:wicket="http://wicket.apache.org">
 <body>
     <wicket:panel>
-        <div wicket:id="enclosing-field-group" class="input-group"
-            style="display: block">
-            <span style="display: table-cell; white-space: nowrap;">
-                <span wicket:id="tooltipLabel"></span> <input
-                wicket:id="field" type="text" placeholder="%"></input> <label
-                wicket:id="label">[[label]]</label>
+        <div wicket:id="enclosing-field-group" class="input-group d-block">
+            <span class="d-table-cell text-nowrap">
+                <span wicket:id="tooltipLabel"></span>
+                    <input wicket:id="field" type="text" placeholder="%" class="d-inline-block"></input>
+                    <label wicket:id="label">[[label]]</label>
             </span>
             <wicket:child />
             <span wicket:id="viewModeField"></span>

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/ToolkitSummernoteEditor.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/ToolkitSummernoteEditor.java
@@ -2,6 +2,7 @@ package org.devgateway.toolkit.forms.wicket.components.form;
 
 import com.google.common.io.BaseEncoding;
 import de.agilecoders.wicket.core.markup.html.bootstrap.form.InputBehavior;
+import de.agilecoders.wicket.core.util.Attributes;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.editor.SummernoteConfig;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.editor.SummernoteEditorCssReference;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.editor.SummernoteEditorFormDataReference;
@@ -9,7 +10,7 @@ import de.agilecoders.wicket.extensions.markup.html.bootstrap.editor.SummernoteE
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.editor.SummernoteEditorOverlayCssReference;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.editor.SummernoteStorage;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.editor.SummernoteStoredImageResourceReference;
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesomeCssReference;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5CssReference;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.references.SpinJsReference;
 import de.agilecoders.wicket.jquery.IKey;
 import org.apache.commons.fileupload.FileItem;
@@ -108,7 +109,7 @@ public class ToolkitSummernoteEditor extends FormComponent<String> {
     @Override
     protected void onComponentTag(final ComponentTag tag) {
         if (!isEnabledInHierarchy()) {
-            tag.put("style", "display:none;");
+            Attributes.addClass(tag, "d-none");
             if (tag.isOpenClose()) {
                 // always transform the tag to <div></div> so even labels defined as <span/> render
                 tag.setType(XmlTag.TagType.OPEN);
@@ -159,7 +160,7 @@ public class ToolkitSummernoteEditor extends FormComponent<String> {
             return;
         }
         response.render(CssHeaderItem.forReference(SummernoteEditorCssReference.instance()));
-        response.render(CssHeaderItem.forReference(FontAwesomeCssReference.instance()));
+        response.render(CssHeaderItem.forReference(FontAwesome5CssReference.instance()));
         response.render(CssHeaderItem.forReference(SummernoteEditorOverlayCssReference.instance()));
         response.render(JavaScriptHeaderItem.forReference(SummernoteEditorJavaScriptReference.instance()));
         response.render(JavaScriptHeaderItem.forReference(SummernoteEditorFormDataReference.instance()));

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/table/AjaxBootstrapNavigator.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/table/AjaxBootstrapNavigator.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:wicket="http://wicket.apache.org">
 <body>
 <wicket:panel>
-    <div class="row" style="float: right">
+    <div class="row float-right">
         <ul class="pagination l-float">
             <li>
                 <a href="#" wicket:id="first" class="first">««</a>

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/AbstractEditStatusEntityPage.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/AbstractEditStatusEntityPage.html
@@ -78,7 +78,7 @@
     <wicket:fragment wicket:id="entityButtons">
         <span wicket:id="extraStatusEntityButtons"></span>
         <button wicket:id="saveSubmit" type="button" class="btn btn-info btn-form-action">Save</button>
-        <button wicket:id="saveContinue" type="button" class="btn btn-info btn-form-action btn-save-as-draft" style="display: none;">Save & Continue</button>
+        <button wicket:id="saveContinue" type="button" class="btn btn-info btn-form-action btn-save-as-draft">Save & Continue</button>
         <button wicket:id="submitAndNext" type="button" class="btn btn-info btn-form-action">Save & Next</button>
         <button wicket:id="approve" type="button" class="btn btn-success btn-form-action">Save & Approve</button>
         <button wicket:id="revertToDraft" type="button" class="btn btn-warning btn-form-action">Save & Validate</button>

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/EditTestFormPage.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/EditTestFormPage.html
@@ -40,6 +40,10 @@
     </div>
 
     <div class="row">
+        <div wicket:id="percentage" class="col-md-4"></div>
+    </div>
+
+    <div class="row">
         <div wicket:id="fileInput" class="col-md-12"></div>
     </div>
 

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/EditTestFormPage.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/EditTestFormPage.java
@@ -31,6 +31,7 @@ import org.devgateway.toolkit.forms.wicket.components.form.ColorPickerBootstrapF
 import org.devgateway.toolkit.forms.wicket.components.form.DateFieldBootstrapFormComponent;
 import org.devgateway.toolkit.forms.wicket.components.form.DateTimeFieldBootstrapFormComponent;
 import org.devgateway.toolkit.forms.wicket.components.form.FileInputBootstrapFormComponent;
+import org.devgateway.toolkit.forms.wicket.components.form.PercentageFieldBootstrapFormComponent;
 import org.devgateway.toolkit.forms.wicket.components.form.Select2ChoiceBootstrapFormComponent;
 import org.devgateway.toolkit.forms.wicket.components.form.Select2MultiChoiceBootstrapFormComponent;
 import org.devgateway.toolkit.forms.wicket.components.form.SummernoteBootstrapFormComponent;
@@ -135,6 +136,10 @@ public class EditTestFormPage extends AbstractEditStatusEntityPage<TestForm> {
         DateTimeFieldBootstrapFormComponent dateTime = new DateTimeFieldBootstrapFormComponent("dateTime");
         dateTime.required();
         editForm.add(dateTime);
+
+        PercentageFieldBootstrapFormComponent percentage = new PercentageFieldBootstrapFormComponent("percentage");
+        percentage.required();
+        editForm.add(percentage);
 
         FileInputBootstrapFormComponent fileInput = new FileInputBootstrapFormComponent("fileInput");
         fileInput.required();

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/EditTestFormPage.properties
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/EditTestFormPage.properties
@@ -20,6 +20,7 @@ checkboxPicker.label=Checkbox Picker
 checkboxToggle.label=Checkbox Toggle
 date.label=Date
 dateTime.label=Datetime
+percentage.label=Percentage
 fileInput.label=File Input
 summernote.label=Summernote Editor
 colorPicker.label=Color Picker

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/lists/AbstractListPage.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/lists/AbstractListPage.html
@@ -16,7 +16,7 @@
     <div class="row">
         <div class="col-md-10 col-md-offset-1">
             <form wicket:id="filterForm">
-                <button type="submit" style="display: none;">Submit</button>
+                <button type="submit" class="d-none">Submit</button>
                 <table class="dataview table" wicket:id="table"></table>
             </form>
             <button wicket:id="new" type="button" class="btn-add-output">

--- a/persistence/src/main/java/org/devgateway/toolkit/persistence/dao/TestForm.java
+++ b/persistence/src/main/java/org/devgateway/toolkit/persistence/dao/TestForm.java
@@ -29,6 +29,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -75,6 +76,8 @@ public class TestForm extends AbstractStatusAuditableEntity {
     private Date date;
 
     private Date dateTime;
+
+    private BigDecimal percentage;
 
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
     @ManyToOne
@@ -159,6 +162,14 @@ public class TestForm extends AbstractStatusAuditableEntity {
 
     public void setDateTime(final Date dateTime) {
         this.dateTime = dateTime;
+    }
+
+    public BigDecimal getPercentage() {
+        return percentage;
+    }
+
+    public void setPercentage(final BigDecimal percentage) {
+        this.percentage = percentage;
     }
 
     public String getSummernote() {


### PR DESCRIPTION
Makes forms code CSP compliant. 

To make the app also CSP compliant `wicket-bootstrap-extension` has to become CSP compliant (affects `BootstrapFileInput`, `ToolkitSummernoteEditor` and likely other). Reported an issue, however it seems this lib is not plannning to be come CSP compliance anytime soon.