### PR TITLE
(4.x) Datetime picker rendering

### DIFF
--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/DateTimeFieldBootstrapFormComponent.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/DateTimeFieldBootstrapFormComponent.java
@@ -10,12 +10,14 @@
  * Development Gateway - initial API and implementation
  *******************************************************************************/
 /**
- * 
+ *
  */
 package org.devgateway.toolkit.forms.wicket.components.form;
 
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.datetime.DatetimePicker;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.datetime.DatetimePickerConfig;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.datetime.DatetimePickerIconConfig;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.IndicatingAjaxLink;
@@ -25,7 +27,7 @@ import java.util.Date;
 
 /**
  * @author mpostelnicu
- * 
+ *
  */
 public class DateTimeFieldBootstrapFormComponent extends GenericBootstrapFormComponent<Date, DatetimePicker> {
     private static final long serialVersionUID = 6829640010904041758L;
@@ -59,17 +61,21 @@ public class DateTimeFieldBootstrapFormComponent extends GenericBootstrapFormCom
     @Override
     protected DatetimePicker inputField(final String id, final IModel<Date> model) {
         config = new DatetimePickerConfig().withFormat(DEFAULT_FORMAT);
+        config.with(
+                new DatetimePickerIconConfig()
+                        .useTimeIcon(FontAwesome5IconType.clock_r));
+
         return new DatetimePicker("field", initFieldModel(), config);
     }
 
     @Override
     public String getUpdateEvent() {
-        return "update";
+        return "change";
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.devgateway.toolkit.forms.wicket.components.form.
      * GenericBootstrapFormComponent#onConfigure()
      */

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.css
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/styles/BaseStyles.css
@@ -128,6 +128,10 @@ hr.edit-separator {
   font-weight: bold;
 }
 
+.bootstrap-datetimepicker-widget .datepicker > div {
+    display: inherit;
+}
+
 /* List View Styles
 -------------------------------------------------- */
 .section-bordered {


### PR DESCRIPTION
It may be a bug in wicket bootstrap extension (one PR comment porting to latest version says "not tested"). 
- the time picker icon fix: explicit configure the icon
- the date picker display fix/workaround: remove "display: none" css config
  - this css existed for 7 years, so either the porting was indeed incomplete or there is a new config we are missing. Lib has nothing documented about it (in wiki/issues/code/samples, e.g. reused the samples they use and they still didn't render).
